### PR TITLE
Возможность использования webhook с уже установленным cert-manager

### DIFF
--- a/deploy/cert-manager-webhook-yandex/Chart.yaml
+++ b/deploy/cert-manager-webhook-yandex/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager-webhook-yandex
 sources: []
-version: 1.0.9
+version: 1.0.10
 description: Yandex Cloud DNS cert-manager ACME webhook
 keywords: []
 maintainers: []
@@ -9,4 +9,7 @@ appVersion: 1.0.3
 deprecated: false
 annotations: {}
 kubeVersion: ""
-dependencies: []
+dependencies:
+- name: cert-manager
+  version: "*"
+  condition: cert-manager.enabled

--- a/deploy/cert-manager-webhook-yandex/templates/ClusterIssuer.yaml
+++ b/deploy/cert-manager-webhook-yandex/templates/ClusterIssuer.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installClusterIssuer.enabled }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -24,5 +25,4 @@ spec:
                 key: key.json
             groupName: acme.cloud.yandex.com
             solverName: yandex-cloud-dns
-            
- 
+{{- end }}

--- a/deploy/cert-manager-webhook-yandex/values.yaml
+++ b/deploy/cert-manager-webhook-yandex/values.yaml
@@ -3,8 +3,8 @@ certManager:
     # must be identical to cert-manager.serviceAccount.name
     serviceAccountName: cert-manager-with-yc-webhook
 image:
-    repository: cr.yandex/yc-marketplace/yandex-cloud/cert-manager-webhook-yandex/cert-manager-webhook-yandex1711961635594770953820309645949480358266192316354
-    tag: 1.0.2
+    repository: cr.yandex/yc-marketplace/yandex-cloud/cert-manager-webhook-yandex/cert-manager-webhook-yandex1749231714289200163949703675370054230465107054664
+    tag: 1.0.3
     pullPolicy: Always
 service:
     type: ClusterIP
@@ -16,7 +16,10 @@ config:
     auth:
         json: |
             {}
+installClusterIssuer:
+    enabled: true
 cert-manager:
+    enabled: true
     image:
         pullPolicy: Always
         repository: quay.io/jetstack/cert-manager-controller


### PR DESCRIPTION
1. Добавлена зависимость (для возможности выключения при использовании оригинального cert-manager)
2. Изменена версия образа (на актуальный)
3. Добавлена возможность отключения установки ClusterIssuer
4. Бамп версии чарта

Поведение чарта по умолчанию сохранено (устанавливается cert-manager из сабчарта, устанавливается ClusterIssuer)